### PR TITLE
Add Ubuntu 17.10 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,5 @@ env:
   - OS_RELEASE=centos7
   - OS_RELEASE=ubuntu1404
   - OS_RELEASE=ubuntu1604
+  - OS_RELEASE=ubuntu1710
   - OS_RELEASE=debian9


### PR DESCRIPTION
Add Ubuntu 17.10 to CI.

- ref: https://github.com/pepabo/ngx_mruby-package-builder/pull/49