### PR TITLE
Fix build error with mruby-redis

### DIFF
--- a/ngx_mruby/build_config.rb
+++ b/ngx_mruby/build_config.rb
@@ -17,7 +17,7 @@ MRuby::Build.new do |conf|
   conf.gem :github => 'iij/mruby-socket'
   conf.gem :github => 'mattn/mruby-json'
   conf.gem :github => 'mattn/mruby-onig-regexp'
-  conf.gem :github => 'matsumoto-r/mruby-redis'
+  conf.gem :github => 'matsumoto-r/mruby-redis', :checksum_hash => 'af40e42492c1a24ec88a15cd56eee9edc7e69788'
   # conf.gem :github => 'matsumoto-r/mruby-memcached'
   conf.gem :github => 'matsumoto-r/mruby-sleep'
   conf.gem :github => 'matsumoto-r/mruby-userdata'


### PR DESCRIPTION
Current master version of mruby-redis cannot build with mruby bundled in ngx_mruby v2.1.1. So, I specified mruby-redis version with compatible one.