### PR TITLE
fix docker-compose command for centos7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       args:
         NGINX_VERSION: ${NGINX_VERSION}
         NGX_MRUBY_VERSION: ${NGX_MRUBY_VERSION}
-    command: cp -a /root/rpmbuild/RPMS/x86_64/nginx-${NGINX_VERSION}-1.el7_4.ngx.x86_64.rpm /tmp
+    command: cp -a /root/rpmbuild/RPMS/x86_64/nginx-${NGINX_VERSION}-1.el7.ngx.x86_64.rpm /tmp
     volumes:
       - .:/tmp:rw
 


### PR DESCRIPTION
fix invalid file name

```bash
$ git rev-parse HEAD
b317c074d69d57485d26e88fb6354de48e56fa55
$ docker-compose run centos7
cp: cannot stat '/root/rpmbuild/RPMS/x86_64/nginx-1.17.7-1.el7_4.ngx.x86_64.rpm': No such file or directory
$ docker-compose run centos7 ls -l /root/rpmbuild/RPMS/x86_64/
total 6132
-rw-r--r-- 1 root root 2189116 Jan 16 09:37 nginx-1.17.7-1.el7.ngx.x86_64.rpm
-rw-r--r-- 1 root root 4085644 Jan 16 09:37 nginx-debuginfo-1.17.7-1.el7.ngx.x86_64.rpm
```