### PR TITLE
Remove some mrbgems from build_config.rb

### DIFF
--- a/ngx_mruby/build_config.rb
+++ b/ngx_mruby/build_config.rb
@@ -8,13 +8,10 @@ MRuby::Build.new do |conf|
     cc.flags << '-fPIE'
   end
 
-  conf.gem :github => 'iij/mruby-io'
   conf.gem :github => 'iij/mruby-env'
   conf.gem :github => 'iij/mruby-dir'
   conf.gem :github => 'iij/mruby-digest'
   conf.gem :github => 'iij/mruby-process'
-  conf.gem :github => 'iij/mruby-pack'
-  conf.gem :github => 'iij/mruby-socket'
   conf.gem :github => 'mattn/mruby-json'
   conf.gem :github => 'mattn/mruby-onig-regexp'
   conf.gem :github => 'matsumoto-r/mruby-redis'

--- a/ngx_mruby/build_config.rb
+++ b/ngx_mruby/build_config.rb
@@ -16,7 +16,6 @@ MRuby::Build.new do |conf|
   conf.gem :github => 'mattn/mruby-onig-regexp'
   conf.gem :github => 'matsumoto-r/mruby-redis'
   # conf.gem :github => 'matsumoto-r/mruby-memcached'
-  conf.gem :github => 'matsumoto-r/mruby-sleep'
   conf.gem :github => 'matsumoto-r/mruby-userdata'
   conf.gem :github => 'matsumoto-r/mruby-uname'
   conf.gem :github => 'matsumoto-r/mruby-mutex'


### PR DESCRIPTION
Remove some mrbgems from `build_config.rb`.

These mrbgems are now bundle as mruby core library (See [mruby/mrbgems](https://github.com/matsumotory/ngx_mruby/tree/master/mruby/mrbgems)). So, no need to explicitly install.