### PR TITLE
Use GitHub Actions as CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: Build Package CI
+
+on: [push]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        os: [centos6, centos7, ubuntu1604, ubuntu1804, debian9]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build package
+      run: docker-compose build ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: Build Package CI
 
-on: [push]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
 


### PR DESCRIPTION
Use GitHub Actions as CI.

GitHub Actions is standard and useful in the Reiwa era.