### PR TITLE
Remove travis-ci configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-sudo: required
-services: docker
-script: docker-compose build $OS_RELEASE
-env:
-  - OS_RELEASE=centos6
-  - OS_RELEASE=centos7
-  - OS_RELEASE=ubuntu1604
-  - OS_RELEASE=ubuntu1804
-  - OS_RELEASE=debian9

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# ngx\_mruby-package-builder [![Build Status](https://travis-ci.org/pepabo/ngx_mruby-package-builder.svg?branch=master)](https://travis-ci.org/pepabo/ngx_mruby-package-builder)
+# ngx\_mruby-package-builder
+
+[![Build Package CI](https://github.com/pepabo/ngx_mruby-package-builder/workflows/Build%20Package%20CI/badge.svg)](https://github.com/pepabo/ngx_mruby-package-builder/actions)
 
 ## Requirements
 


### PR DESCRIPTION
We use GitHub Actions as CI https://github.com/pepabo/ngx_mruby-package-builder/pull/87 now.

So...

- Remove travis-ci configuration file.
- Adjust README.