### PR TITLE
Rename owner name of dependent repositories

### DIFF
--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -16,7 +16,7 @@ ADD ngx_mruby/centos/nginx.spec.patch /root/rpmbuild/SPECS/nginx.spec.patch
 RUN patch -p0 < nginx.spec.patch
 
 WORKDIR /usr/local/src
-RUN git clone --branch v$NGX_MRUBY_VERSION --depth 1 https://github.com/matsumoto-r/ngx_mruby.git
+RUN git clone --branch v$NGX_MRUBY_VERSION --depth 1 https://github.com/matsumotory/ngx_mruby.git
 
 # RUN yum -y update
 

--- a/Dockerfile.ubuntu1604
+++ b/Dockerfile.ubuntu1604
@@ -14,7 +14,7 @@ RUN apt-get -qq build-dep -y nginx="$NGINX_VERSION"
 RUN apt-get -qq source nginx="$NGINX_VERSION"
 
 WORKDIR /usr/local/src
-RUN git clone --branch v$NGX_MRUBY_VERSION --depth 1 https://github.com/matsumoto-r/ngx_mruby.git
+RUN git clone --branch v$NGX_MRUBY_VERSION --depth 1 https://github.com/matsumotory/ngx_mruby.git
 
 RUN apt-get -qq dist-upgrade -y
 

--- a/Dockerfile.ubuntu1804
+++ b/Dockerfile.ubuntu1804
@@ -14,7 +14,7 @@ RUN apt-get -qq build-dep -y nginx="$NGINX_VERSION"
 RUN apt-get -qq source nginx="$NGINX_VERSION"
 
 WORKDIR /usr/local/src
-RUN git clone --branch v$NGX_MRUBY_VERSION --depth 1 https://github.com/matsumoto-r/ngx_mruby.git
+RUN git clone --branch v$NGX_MRUBY_VERSION --depth 1 https://github.com/matsumotory/ngx_mruby.git
 
 RUN apt-get -qq dist-upgrade -y
 

--- a/ngx_mruby/build_config.rb
+++ b/ngx_mruby/build_config.rb
@@ -14,12 +14,12 @@ MRuby::Build.new do |conf|
   conf.gem :github => 'iij/mruby-process'
   conf.gem :github => 'mattn/mruby-json'
   conf.gem :github => 'mattn/mruby-onig-regexp'
-  conf.gem :github => 'matsumoto-r/mruby-redis'
-  # conf.gem :github => 'matsumoto-r/mruby-memcached'
-  conf.gem :github => 'matsumoto-r/mruby-userdata'
-  conf.gem :github => 'matsumoto-r/mruby-uname'
-  conf.gem :github => 'matsumoto-r/mruby-mutex'
-  conf.gem :github => 'matsumoto-r/mruby-localmemcache'
+  conf.gem :github => 'matsumotory/mruby-redis'
+  # conf.gem :github => 'matsumotory/mruby-memcached'
+  conf.gem :github => 'matsumotory/mruby-userdata'
+  conf.gem :github => 'matsumotory/mruby-uname'
+  conf.gem :github => 'matsumotory/mruby-mutex'
+  conf.gem :github => 'matsumotory/mruby-localmemcache'
 
   # ngx_mruby extended class
   conf.gem './mrbgems/ngx_mruby_mrblib'


### PR DESCRIPTION
Rename owner name of dependent repositories.

- `matsumoto-r` is now rename to `matsumotory`. (currently redirected)